### PR TITLE
docs: SvelteComponent -> SvelteApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Normal props behave as you would expect.
 import React, { useState } from "react";
 import toReact from "svelte-adapter/react";
 
-import SvelteComponent from "../App.svelte";
+import SvelteApp from "../App.svelte";
 
 const baseStyle = {
   width: "50%"


### PR DESCRIPTION
In the Vue example it shows the import as `SvelteApp`, which is what is used in the `SvelteInReact` component in the React example however it was imported as `SvelteComponent`