### PR TITLE
Destroy svelte component when vue adepter destroyed

### DIFF
--- a/vue.js
+++ b/vue.js
@@ -49,5 +49,8 @@ export default (Component, style = {}, tag = "span") =>
     },
     updated() {
       this.comp.$set(this.$attrs);
+    },
+    destroyed() {
+      this.comp.$destroy();
     }
   });


### PR DESCRIPTION
- call `$destroy` when vue adapter destroyed