### PR TITLE
Update Svelte version and watchers handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^16.5.0",
     "rollup": "^1.16.2",
     "sirv-cli": "^0.2.0",
-    "svelte": "^3.5.3",
+    "svelte": "^3.20.1",
     "svelte-easy-crop": "^1.0.3",
     "svelte-loader": "^2.13.4",
     "vue": "^2.6.10"

--- a/react.js
+++ b/react.js
@@ -35,7 +35,8 @@ export default (Component, style = {}, tag = "span") => props => {
       const update = component.current.$$.update;
       component.current.$$.update = function() {
         watchers.forEach(([name, callback]) => {
-          callback(component.current.$$.ctx[name]);
+          const index = component.current.$$.props[name];
+          callback(component.current.$$.ctx[index]);
         });
         update.apply(null, arguments);
       };

--- a/vue.js
+++ b/vue.js
@@ -41,7 +41,8 @@ export default (Component, style = {}, tag = "span") =>
         const update = this.comp.$$.update;
         this.comp.$$.update = function() {
           watchers.forEach(([name, callback]) => {
-            callback(comp.$$.ctx[name]);
+            const index = comp.$$.props[name];
+            callback(comp.$$.ctx[index]);
           });
           update.apply(null, arguments);
         };


### PR DESCRIPTION
Svelte internal changes tracking was updated since version 3.16.
